### PR TITLE
fix: the text looked blurry when zooming in. 

### DIFF
--- a/compiler.worker.ts
+++ b/compiler.worker.ts
@@ -35,7 +35,7 @@ onmessage = (ev: MessageEvent<CompileCommand | true>) => {
         ev.data.forEach(font => compiler.add_font(new Uint8Array(font)))
     } else if ("source" in ev.data) {
         const data: CompileCommand = ev.data;
-        postMessage(compiler.compile(data.source, data.path, data.pixel_per_pt, data.fill, data.size, data.display))
+        postMessage(compiler.compile(data.source, data.path, data.pixel_per_pt, data.scale, data.fill, data.size, data.display))
 
         // postMessage(compile(ev.data))
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ impl SystemWorld {
         text: String,
         path: String,
         pixel_per_pt: f32,
+        scale: f32,
         fill: String,
         size: u32,
         display: bool,
@@ -107,7 +108,7 @@ impl SystemWorld {
             Ok(document) => {
                 let mut pixmap = typst::export::render(
                     &document.pages[0],
-                    pixel_per_pt,
+                    pixel_per_pt * scale,
                     Color::Rgba(RgbaColor::from_str(&fill)?),
                 );
 
@@ -128,16 +129,17 @@ impl SystemWorld {
                     .multiply_alpha_inplace(&mut src_image.view_mut())
                     .unwrap();
 
+                let scaled_size = ((size as f32) * scale).floor() as u32;
                 let dst_width = NonZeroU32::new(if display {
-                    size
+                    scaled_size
                 } else {
-                    ((size as f32 / height as f32) * width as f32) as u32
+                    ((scaled_size as f32 / height as f32) * width as f32) as u32
                 })
                 .unwrap_or(NonZeroU32::MIN);
                 let dst_height = NonZeroU32::new(if display {
-                    ((size as f32 / width as f32) * height as f32) as u32
+                    ((scaled_size as f32 / width as f32) * height as f32) as u32
                 } else {
-                    size
+                    scaled_size
                 })
                 .unwrap_or(NonZeroU32::MIN);
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,6 +2,7 @@ export interface CompileCommand {
     source: string;
     path: string;
     pixel_per_pt: number;
+    scale: number;
     fill: string;
     size: number;
     display: boolean;

--- a/typst-canvas-element.ts
+++ b/typst-canvas-element.ts
@@ -1,5 +1,5 @@
 export default class TypstCanvasElement extends HTMLCanvasElement {
-    static compile: (path: string, source: string, size: number, display: boolean, fontSize: number) => Promise<ImageData>;
+    static compile: (path: string, source: string, size: number, display: boolean, fontSize: number, scale: number) => Promise<ImageData>;
     static nextId = 0;
     static prevHeight = 0;
 
@@ -8,6 +8,7 @@ export default class TypstCanvasElement extends HTMLCanvasElement {
     source: string
     path: string
     display: boolean
+    scale: number
     resizeObserver: ResizeObserver
     size: number
     math: boolean
@@ -60,9 +61,10 @@ export default class TypstCanvasElement extends HTMLCanvasElement {
 
                 let image: ImageData;
                 let ctx = this.getContext("2d")!;
+
                 try {
                     image =
-                        await TypstCanvasElement.compile(this.path, this.source, this.size, this.display, fontSize)
+                        await TypstCanvasElement.compile(this.path, this.source, this.size, this.display, fontSize, this.scale)
                 } catch (error) {
                     console.error(error);
                     this.outerText = error


### PR DESCRIPTION

When we were scaling the window with obsidian "Zoom in" command, we could see that the text was blurry. This was because the plugin was not scaling the image to preserve the pixels.  
It was fixed by using a new parameter called 'scale'. 

Note that this is my first commit with this project, and as I am new with this codebase, I may have made some errors.

Pics: 

> ![scaling-1-before-fix](https://github.com/fenjalien/obsidian-typst/assets/30377970/aa727e59-47f5-4bed-aba2-67ec3eaf48ff)
> Rendering with scaling at 1

> ![scaling-1-7-before-fix](https://github.com/fenjalien/obsidian-typst/assets/30377970/4fa0ef72-3444-48a3-b1df-394751332127)
> Rendering with scaling at 1.7 before the fix, we can see that the text looks blurry 

> ![scaling-1-7-after-fix](https://github.com/fenjalien/obsidian-typst/assets/30377970/605f2be7-ca89-4a13-8559-7540a57e6f55)
> Rendering with scaling at 1.7 after the fix, now the text looks clean 
