### PR TITLE
Fix typo; preamable vs preamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ From what I've experimented with, normal math blocks are okay with Typst but Typ
 
 For styling and using imports with math blocks see the next section.
 
-## Preamables
-Need to style your `typst` code the same way everytime and don't to write it out each time? Or using math blocks and need a way to import things? Use PREAMABLES! 
+## Preambles
+Need to style your `typst` code the same way everytime and don't to write it out each time? Or using math blocks and need a way to import things? Use PREAMBLES! 
 
-Preamables are prepended to your `typst` code before compiling. There are three different types in settings:
+Preambles are prepended to your `typst` code before compiling. There are three different types in settings:
 - `shared`: Prepended to all `typst` code.
 - `math`: Prepended to `typst` code only in math blocks.
 - `code`: Prepended to `typst` code only in code blocks.

--- a/main.ts
+++ b/main.ts
@@ -337,13 +337,13 @@ class TypstSettingTab extends PluginSettingTab {
             });
 
         new Setting(containerEl)
-            .setName("Shared Preamable")
+            .setName("Shared Preamble")
             .addTextArea((c) => c.setValue(this.plugin.settings.preamable.shared).onChange(async (value) => { this.plugin.settings.preamable.shared = value; await this.plugin.saveSettings() }))
         new Setting(containerEl)
-            .setName("Code Block Preamable")
+            .setName("Code Block Preamble")
             .addTextArea((c) => c.setValue(this.plugin.settings.preamable.code).onChange(async (value) => { this.plugin.settings.preamable.code = value; await this.plugin.saveSettings() }))
         new Setting(containerEl)
-            .setName("Math Block Preamable")
+            .setName("Math Block Preamble")
             .addTextArea((c) => c.setValue(this.plugin.settings.preamable.math).onChange(async (value) => { this.plugin.settings.preamable.math = value; await this.plugin.saveSettings() }))
 
         //Font family settings


### PR DESCRIPTION
I didn't change the variable names since that would (probably) break settings for people who already have this installed. This is just a cosmetic change