### PR TITLE
fix: canvas duplication

### DIFF
--- a/src/typst-render-element.ts
+++ b/src/typst-render-element.ts
@@ -31,7 +31,7 @@ export default class TypstRenderElement extends HTMLElement {
         // this.style.height = TypstRenderElement.prevHeight;
         // }
 
-        if (this.format == "image") {
+        if (this.format == "image" && this.canvas == undefined) {
             this.canvas = this.appendChild(createEl("canvas", { attr: { height: TypstRenderElement.prevHeight }, cls: "typst-doc" }))
         }
 


### PR DESCRIPTION
Fixes #25. If the canvas already exists, it doesn't create a new canvas.