### PR TITLE
Fix: wrong paths generated for `@local`/`@preview` packages

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -201,7 +201,7 @@ impl SystemWorld {
                     .js_request_data
                     .call1(
                         &JsValue::NULL,
-                        &format!("@{}/{}-{}", spec.namespace, spec.name, spec.version).into(),
+                        &format!("@{}/{}/{}", spec.namespace, spec.name, spec.version).into(),
                     )
                     .map_err(f)?
                     .as_string()

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,12 +185,12 @@ export default class TypstPlugin extends Plugin {
         spec = spec.slice(1)
         let subdir = "/typst/packages/" + spec
 
-        let dir = normalizePath(this.getDataDir() + subdir)
+        let dir = require('path').normalize(this.getDataDir() + subdir)
         if (this.fs.existsSync(dir)) {
             return dir
         }
 
-        dir = normalizePath(this.getCacheDir() + subdir)
+        dir = require('path').normalize(this.getCacheDir() + subdir)
 
         if (this.fs.existsSync(dir)) {
             return dir


### PR DESCRIPTION
Prior to these changes, typst packages could not be imported. 

- Changed the formatted path in `SystemWorld::prepare_package` to represent the current structure of packages (`namespace/name/version`), which allows typst to find and detect the existence of packages (before this, importing packages resulted in a "package not found" error)
- Use `path.normalize()` in place of `obsidian.normalizePath()` in `preparePackage()`, because the latter always interprets paths as being relative to the vault, but namespaced packages (i.e. `@local`/`@preview`) always refer to paths outside of the vault