### PR TITLE
feat: custom package path

### DIFF
--- a/src/settings/folder-suggest.ts
+++ b/src/settings/folder-suggest.ts
@@ -1,0 +1,20 @@
+import { AbstractInputSuggest, App, TFolder } from "obsidian";
+
+export class FolderSuggest extends AbstractInputSuggest<string> {
+    constructor(app: App, private inputEl: HTMLInputElement) {
+        super(app, inputEl);
+    }
+    protected getSuggestions(query: string): string[] {
+        // @ts-ignore "getAllFolders" exists but is undocumented.
+        return (this.app.vault.getAllFolders() as TFolder[])
+            .filter(folder => folder.path.contains(query))
+            .map(folder => folder.path);
+    }
+    renderSuggestion(value: string, el: HTMLElement): void {
+        el.setText(value);
+    }
+    selectSuggestion(value: string, evt: MouseEvent | KeyboardEvent): void {
+        this.inputEl.value = value;
+        this.close();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,10 @@ typst-renderer {
 
 }
 
+.save-path-btn {
+    margin-left: 0.5em;
+}
+
 .delete-pkg-btn {
     margin-top: 1.5em;
     width: max-content;


### PR DESCRIPTION
Closes #52. Currently only works on the Desktop app due to #38.

If `Use custom package path` is checked, the user have to choose a path and click on the save button.
If the user reloads without saving, the path will be the default `packages/` in the vault root.

- Pros:
  - Possibility to read the `README.md` of each package.
  - Possibility to read each `.typ` in the future when [Custom editor for `.typ` files](https://github.com/fenjalien/obsidian-typst?tab=readme-ov-file#todo--goals-in-no-particular-order) works. (currently can be shown only in the file tree if `Detect all file extensions` is enabled on _Files and links_ settings) 
- Cons:
  - These folders will be visible on the **Quick Switcher**, if we have many folders this could be annoying, but is up to the user to use this option.

This feature doesn't require reload.

I'm not fluent in English, please let me know if there any typos.